### PR TITLE
Update Node.js 12 to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,5 +59,5 @@ inputs:
     default: OFF
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Thank you very much for your project. I've been using it in my projects. Until recently GitHub Action warned me:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: Dovyski/setup-opencv-action`

So this is just a tiny Pull request that just changes the Node.js version.